### PR TITLE
Manifests

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "escape-html": "^1.0.2",
     "exec-async": "^2.2.0",
     "exists-async": "^2.0.0",
+    "express": "^4.13.3",
+    "express-http-proxy": "^0.6.0",
     "freeport-async": "^1.1.0",
     "fs-extra": "^0.26.0",
     "git-info-async": "^1.1.0",

--- a/src/application/Api.js
+++ b/src/application/Api.js
@@ -1,5 +1,6 @@
 'use strict';
 
+let _ = require('lodash-node');
 let instapromise = require('instapromise');
 let request = require('request');
 
@@ -19,11 +20,10 @@ if (config.api.port) {
   API_BASE_URL += ':' + config.api.port;
 }
 API_BASE_URL += '/--/api/';
-// const API_BASE_URL = 'http://localhost:3000/--/api/';
 
 export default class ApiClient {
 
-  static async callMethodAsync(methodName, args) {
+  static async callMethodAsync(methodName, args, method, requestBody) {
     let url = API_BASE_URL + encodeURIComponent(methodName) + '/' +
       encodeURIComponent(JSON.stringify(args));
 
@@ -38,13 +38,30 @@ export default class ApiClient {
 
     // console.log("headers=", headers);
 
-    let response = await request.promise.get(url, {headers});
-    let body = response.body;
+    let options = {
+      url,
+      method: method || 'get',
+      headers,
+    };
+    if (requestBody) {
+      options = {
+        ...options,
+        body: requestBody,
+        json: true,
+      }
+    }
+
+    let response = await request.promise(options);
+    let responseBody = response.body;
     var responseObj;
-    try {
-      responseObj  = JSON.parse(body);
-    } catch (e) {
-      throw new Error("Invalid JSON returned from API: " + e);
+    if (_.isString(responseBody)) {
+      try {
+        responseObj = JSON.parse(responseBody);
+      } catch (e) {
+        throw new Error("Invalid JSON returned from API: " + e);
+      }
+    } else {
+      responseObj = responseBody;
     }
     if (responseObj.err) {
       let err = ApiError(responseObj.code || 'API_ERROR', "API Response Error: " + responseObj.err);

--- a/src/application/Exp.js
+++ b/src/application/Exp.js
@@ -29,7 +29,7 @@ async function determineEntryPoint(root) {
 }
 
 async function _getReactNativeVersionAsync() {
-  let xdePackageJson =  jsonFile(path.join(__dirname, '../../package.json'));
+  let xdePackageJson = jsonFile(path.join(__dirname, '../../package.json'));
   return await xdePackageJson.getAsync(['dependencies', 'react-native']);
 }
 
@@ -40,7 +40,6 @@ async function _installReactNativeInNewProjectWithRoot(root) {
 }
 
 async function createNewExpAsync(root, info, opts) {
-
   let pp = path.parse(root);
   let name = pp.name;
 
@@ -88,7 +87,6 @@ async function createNewExpAsync(root, info, opts) {
   await _installReactNativeInNewProjectWithRoot(root);
 
   return data;
-
 }
 
 async function saveRecentExpRootAsync(root) {
@@ -138,7 +136,6 @@ async function expInfoSafeAsync(root) {
 }
 
 async function getPublishInfoAsync(env, opts) {
-
   let root = env.root;
   let pkgJson = packageJsonForRoot(root);
   let pkg = await pkgJson.readAsync();
@@ -159,7 +156,7 @@ async function getPublishInfoAsync(env, opts) {
   let localPackageName = name;
   let packageVersion = version;
 
-  let ngrokUrl = urlUtils.constructUrl(packagerController, {
+  let ngrokUrl = urlUtils.constructBundleUrl(packagerController, {
     ngrok: true,
     dev: false,
     minify: true,
@@ -167,16 +164,18 @@ async function getPublishInfoAsync(env, opts) {
   });
 
   return {
-    username,
-    localPackageName,
-    packageVersion,
-    remoteUsername,
-    remotePackageName,
-    remoteFullPackageName,
-    ngrokUrl,
+    args: {
+      username,
+      localPackageName,
+      packageVersion,
+      remoteUsername,
+      remotePackageName,
+      remoteFullPackageName,
+      ngrokUrl,
+    },
+    body: pkg,
   };
 }
-
 
 async function recentValidExpsAsync() {
   let recentExpsJsonFile = userSettings.recentExpsJsonFile();
@@ -200,5 +199,6 @@ module.exports = {
   getPublishInfoAsync,
   saveRecentExpRootAsync,
   recentValidExpsAsync,
+  packageJsonForRoot,
   _getReactNativeVersionAsync,
 };

--- a/src/application/urlUtils.js
+++ b/src/application/urlUtils.js
@@ -3,9 +3,15 @@ let myLocalIp = require('my-local-ip');
 let os = require('os');
 let url = require('url');
 
-function constructUrl(pc, opts) {
+function constructBundleUrl(packageController, opts) {
+  return constructUrl(packageController, opts, 'bundle');
+}
 
-  // crayon.blue.log("constructUrl");
+function constructManifestUrl(packageController, opts) {
+  return constructUrl(packageController, opts, '');
+}
+
+function constructUrl(packageController, opts, path) {
   opts = opts || {};
 
   let protocol = 'exp';
@@ -18,15 +24,15 @@ function constructUrl(pc, opts) {
 
   if (opts.localhost) {
     hostname = 'localhost';
-    port = pc.opts.port;
+    port = packageController.opts.port;
   } else if (opts.lan) {
     hostname = os.hostname();
-    port = pc.opts.port;
+    port = packageController.opts.port;
   } else if (opts.lanIp) {
     hostname = myLocalIp;
-    port = pc.opts.port;
+    port = packageController.opts.port;
   } else {
-    let ngrokUrl = pc.getNgrokUrl();
+    let ngrokUrl = packageController.getNgrokUrl();
     if (!ngrokUrl) {
       throw new Error("Can't get ngrok URL because ngrok not started yet");
     }
@@ -36,37 +42,17 @@ function constructUrl(pc, opts) {
     port = pnu.port;
   }
 
-  // console.log("opts=", opts);
-
   let url_ = protocol + '://' + hostname;
   if (port) {
     url_ += ':' + port;
   }
 
-  let entryPoint = pc.opts.entryPoint || 'index.js';
-  let mainModulePath = opts.mainModulePath || guessMainModulePath(entryPoint);
-  // console.log("entryPoint=", entryPoint, "mainModulePath=", mainModulePath);
-  url_ += '/' + encodeURIComponent(mainModulePath) + '.';
+  url_ += '/' + path;
 
-  if (opts.includeRequire) {
-    url_ += encodeURIComponent('includeRequire.');
-  }
-
-  if (opts.runModule) {
-    url_ += encodeURIComponent('runModule.');
-  }
-
-  url_ += 'bundle';
-
-  let platform = opts.platform || 'ios';
-  url_ += '?platform=' + encodeURIComponent(platform);
-
-  url_ += '&dev=' + encodeURIComponent(!!opts.dev);
+  url_ += '?dev=' + encodeURIComponent(!!opts.dev);
   if (opts.minify) {
     url_ += '&minify=' + encodeURIComponent(!!opts.minify);
   }
-
-  // console.log("url_=", url_);
 
   if (opts.redirect) {
     return 'http://exp.host/--/to-exp/' + encodeURIComponent(url_);
@@ -89,7 +75,8 @@ function guessMainModulePath(entryPoint) {
 }
 
 module.exports = {
-  constructUrl,
+  constructBundleUrl,
+  constructManifestUrl,
   expUrlFromHttpUrl,
   httpUrlFromExpUrl,
   guessMainModulePath,

--- a/src/ui/App.js
+++ b/src/ui/App.js
@@ -41,7 +41,6 @@ class App extends React.Component {
       packagerErrors: '',
       url: null,
       hostType: 'ngrok',
-      platform: 'ios',
       dev: true,
       minify: false,
       sendInput: null,
@@ -379,18 +378,6 @@ class App extends React.Component {
         <ButtonGroup style={{
             marginRight: buttonGroupSpacing,
         }}>
-          <Button bsSize="small" {...{active: (this.state.platform === 'ios')}} onClick={(event) => {
-              this.setState({platform: 'ios'});
-              event.target.blur();
-          }}>iOS</Button>
-        <Button bsSize="small" {...{active: (this.state.platform === 'android')}} onClick={(event) => {
-              this.setState({platform: 'android'});
-              event.target.blur();
-          }}>Android</Button>
-        </ButtonGroup>
-        <ButtonGroup style={{
-            marginRight: buttonGroupSpacing,
-        }}>
           <Button bsSize="small" {...{active: this.state.dev}}  onClick={(event) => {
               this.setState({dev: !this.state.dev});
               event.target.blur();
@@ -441,14 +428,13 @@ class App extends React.Component {
 
   @autobind
   _publishClicked() {
-
     this._logMetaMessage("Publishing...");
 
     Exp.getPublishInfoAsync(this.state.env, {
       packagerController: this.state.packagerController,
       username: this.state.user.username,
     }).then((publishInfo) => {
-      return Api.callMethodAsync('publish', [publishInfo]).then((result) => {
+      return Api.callMethodAsync('publish', [publishInfo.args], 'post', publishInfo.body).then((result) => {
         // this._logMetaMessage("Published " + result.packageFullName + " to " + result.expUrl);
         this._logMetaMessage("Published to " + result.expUrl);
         console.log("Published", result);
@@ -770,13 +756,12 @@ class App extends React.Component {
       ngrok: (this.state.hostType === 'ngrok'),
       lan: (this.state.hostType === 'lan'),
       localhost: (this.state.hostType === 'localhost'),
-      platform: this.state.platform,
       dev: this.state.dev,
       minify: this.state.minify,
       redirect: (this.state.urlType === 'redirect'),
     };
 
-    return urlUtils.constructUrl(this.state.packagerController, opts);
+    return urlUtils.constructManifestUrl(this.state.packagerController, opts);
   }
 
 };

--- a/src/ui/SimulatorControls.js
+++ b/src/ui/SimulatorControls.js
@@ -68,7 +68,7 @@ class Simulator extends React.Component {
   }
 
   _projectUrl() {
-    return urlUtils.constructUrl(this.props.packagerController, {
+    return urlUtils.constructManifestUrl(this.props.packagerController, {
       localhost: true,
       dev: this.props.dev,
       minify: this.props.minify,


### PR DESCRIPTION
Move the packager to port 19001. Run a server on port 19000 that either proxies to the packager or returns a manifest generated from the `exp` field in package.json. Send package.json to publish endpoint.
