### PR TITLE
[manifest] Support manifests at index.exp and remove query params from url

### DIFF
--- a/src/application/urlUtils.js
+++ b/src/application/urlUtils.js
@@ -16,6 +16,15 @@ function constructDebuggerHost(packageController) {
   return ip.address() + ':' + packageController.opts.packagerPort;
 }
 
+function constructBundleQueryParams(opts) {
+  let queryParams = 'dev=' + encodeURIComponent(!!opts.dev);
+  if (opts.minify) {
+    queryParams += '&minify=' + encodeURIComponent(!!opts.minify);
+  }
+
+  return queryParams;
+}
+
 function constructUrl(packageController, opts, path) {
   opts = opts || {};
 
@@ -52,13 +61,6 @@ function constructUrl(packageController, opts, path) {
     url_ += ':' + port;
   }
 
-  url_ += '/' + path;
-
-  url_ += '?dev=' + encodeURIComponent(!!opts.dev);
-  if (opts.minify) {
-    url_ += '&minify=' + encodeURIComponent(!!opts.minify);
-  }
-
   if (opts.redirect) {
     return 'http://exp.host/--/to-exp/' + encodeURIComponent(url_);
   }
@@ -83,6 +85,7 @@ module.exports = {
   constructBundleUrl,
   constructManifestUrl,
   constructDebuggerHost,
+  constructBundleQueryParams,
   expUrlFromHttpUrl,
   httpUrlFromExpUrl,
   guessMainModulePath,

--- a/src/ui/App.js
+++ b/src/ui/App.js
@@ -762,6 +762,7 @@ class App extends React.Component {
       redirect: (this.state.urlType === 'redirect'),
     };
 
+    this.state.packagerController.appOpts = opts;
     return urlUtils.constructManifestUrl(this.state.packagerController, opts);
   }
 


### PR DESCRIPTION
Serve manifest at index.exp. Also remove `dev` and `minified` query params from the experience url, and add them to the bundle url returned from the manifest.
