### PR TITLE
Remove image shadow keys

### DIFF
--- a/template/ExPhotoGallery.js
+++ b/template/ExPhotoGallery.js
@@ -65,10 +65,6 @@ let styles = StyleSheet.create({
     overflow: 'visible',
   },
   photo: {
-    shadowRadius: 3,
-    shadowColor: '#000',
-    shadowOpacity: 0.3,
-    shadowOffset: { width: 0, height: 1 },
     overflow: 'visible',
   },
 });


### PR DESCRIPTION
When running the demo app, seeing error messages:

```
Warning: Failed propType: Invariant Violation: Invalid props.style key <key> supplied to `Image`
```

These keys give the warning which produces a lot of red in the console on first load of app:

```
shadowRadius
shadowColor
shadowOpacity
shadowOffset
```

removing these keys removes the warnings from console and the app is running fine :)
