### PR TITLE
Fix warnings on sample app

### DIFF
--- a/template/ExPhotoGallery.js
+++ b/template/ExPhotoGallery.js
@@ -63,12 +63,12 @@ let styles = StyleSheet.create({
   photoContainer: {
     marginHorizontal: PHOTO_SPACING / 2,
     overflow: 'visible',
-  },
-  photo: {
     shadowRadius: 3,
     shadowColor: '#000',
     shadowOpacity: 0.3,
     shadowOffset: { width: 0, height: 1 },
+  },
+  photo: {
     overflow: 'visible',
   },
 });


### PR DESCRIPTION
Just downloaded the new version and going to the sample app showed a few yellow box warnings about shadow style props.
