### PR TITLE
Fix "Clear Packager Cache"

### DIFF
--- a/src/application/PackagerController.js
+++ b/src/application/PackagerController.js
@@ -129,7 +129,7 @@ class PackagerController extends events.EventEmitter {
     return this._ngrokUrl;
   }
 
-  async startOrRestartPackagerAsync() {
+  async startOrRestartPackagerAsync(options = {}) {
     if (!this.opts.packagerPort) {
       throw new Error("`this.opts.packagerPort` must be set before starting the packager!");
     }
@@ -141,16 +141,21 @@ class PackagerController extends events.EventEmitter {
 
     await this._stopPackagerAsync();
 
+    let cliOpts = ['start',
+      '--port', this.opts.packagerPort,
+      '--projectRoots', root,
+      '--assetRoots', root,
+    ];
+
+    if (options.reset) {
+      cliOpts.push('--reset-cache');
+    }
+    
     // Run the copy of Node that's embedded in Electron by setting the
     // ELECTRON_RUN_AS_NODE environment variable
     // Note: the CLI script sets up graceful-fs and sets ulimit to 4096 in the
     // child process
-    let packagerProcess = child_process.fork(this.opts.cliPath, [
-      'start',
-      '--port', this.opts.packagerPort,
-      '--projectRoots', root,
-      '--assetRoots', root,
-    ], {
+    let packagerProcess = child_process.fork(this.opts.cliPath, cliOpts, {
       cwd: path.dirname(path.dirname(this.opts.cliPath)),
       env: {
         ...process.env,

--- a/src/ui/App.js
+++ b/src/ui/App.js
@@ -556,21 +556,15 @@ class App extends React.Component {
   _resetPackagerClicked() {
     console.log("Clearing the packager cache");
     this._logMetaMessage("Clearing the packager cache");
-    let cacheGlob = path.join(os.tmpdir(), 'react-packager-cache-*');
-    return del(cacheGlob, { force: true }).then(() => {
-      return this._restartPackagerClicked();
-    }, error => {
-      console.error("Failed to clear the packager cache: " + error.message);
-      this._logMetaError("Failed to clear the packager cache: " + error.message);
-    });
+    this._restartPackagerClicked({ reset: true });
   }
 
   @autobind
-  _restartPackagerClicked() {
+  _restartPackagerClicked(options) {
     if (this.state.packagerController) {
       console.log("Restarting packager...");
       this._logMetaMessage("Restarting packager...");
-      this.state.packagerController.startOrRestartPackagerAsync().then(() => {
+      this.state.packagerController.startOrRestartPackagerAsync(options).then(() => {
         console.log("Packager restarted :)");
       }, (err) => {
         console.error("Failed to restart packager :(");


### PR DESCRIPTION
Rather than manually delete files in the os.tmpdir (for some reason the packager doesn't always use that particular temp dir), use the "reset-cache" cli option. This future proofs us a bit, because that behavior may change in the RN packager in the future.

cc @ide
