### PR TITLE
Set default font.

### DIFF
--- a/app/web/xde.css
+++ b/app/web/xde.css
@@ -4,7 +4,7 @@ BODY {
   overflow: hidden;
   height: 100%;
   width: 100%;
-  font-family: 'Verdana', 'Helvetica Neue';
+  font-family: 'Verdana', 'Helvetica Neue', sans-serif;
 }
 PRE {
   border: none;


### PR DESCRIPTION
This will fall back to a nicer font on systems that don't have Verdana or Helvetica Neue (i.e., Linux), otherwise all the fonts appear as serif.