### PR TITLE
Add action verb to send link placeholder

### DIFF
--- a/src/ui/toolbar/ToolBar.js
+++ b/src/ui/toolbar/ToolBar.js
@@ -282,7 +282,7 @@ class ToolBar extends React.Component {
             this._sendLinkInput = r;
           }}
           defaultValue={this.props.sendTo}
-          placeholder="Email or phone"
+          placeholder="Enter email or phone"
         />
         <a
           onClick={this._onSendLinkClick}


### PR DESCRIPTION
Now the send link placeholder explicitly askes the user to enter an email or phone number. Before it looked like a disabled button and was confusing.